### PR TITLE
Creates encrypted cipher stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["protocol", "datrs"]
 readme = "README.md"
 
 [dependencies]
-async-std = { version = "1.0.1", features = ["unstable"] }
+async-std = { version = "1.4.0", features = ["unstable"] }
 varinteger = "1.0.6"
 futures = "0.3.1"
+salsa20 = "0.4.0"

--- a/examples/tcp_encrypted.rs
+++ b/examples/tcp_encrypted.rs
@@ -138,7 +138,7 @@ fn create_from_stream(
     Arc<RwLock<Cipher>>,
 ) {
     let stream = CloneableStream(Arc::new(tcp_stream));
-    let cipher = Arc::new(RwLock::new(Cipher::new(KEY)));
+    let cipher = Arc::new(RwLock::new(Cipher::new(KEY.to_vec())));
     let reader = Reader::encrypted(stream.clone(), cipher.clone(), |message, cypher| {
         if message.typ == 0 {
             println!("Received message nonce: {:?}", message);

--- a/examples/tcp_encrypted.rs
+++ b/examples/tcp_encrypted.rs
@@ -1,0 +1,183 @@
+//! TCP example
+//!
+//! This demonstrates how to use simple-message-channels with TCP.
+//!
+//! Usage:
+//! In one terminal run
+//!
+//! cargo run --example tcp -- server 127.0.0.1:8080
+//!
+//! and in another
+//!
+//! cargo run --example tcp -- client 127.0.0.1:8080
+//!
+//! This should send a message "hi" on channel 1, typ 1,
+//! and the server should reply with "HI" on channel 1, typ 2.
+
+use async_std::net::{TcpListener, TcpStream};
+use async_std::prelude::*;
+use async_std::task;
+use async_std::task::{Context, Poll};
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::stream::TryStreamExt;
+use simple_message_channels::{Cipher, Message, Reader, Writer};
+use std::env;
+use std::io::{ErrorKind, Result};
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+
+const KEY: [u8; 32] = [
+    175, 39, 20, 85, 161, 205, 167, 90, 216, 97, 221, 165, 181, 230, 252, 255, 152, 97, 3, 147,
+    136, 113, 103, 131, 220, 137, 252, 245, 145, 202, 203, 199,
+];
+
+const INITIAL_NONCE: [u8; 24] = [
+    115, 178, 69, 191, 80, 7, 234, 242, 12, 167, 90, 109, 25, 41, 111, 139, 66, 238, 114, 62, 25,
+    164, 36, 153,
+];
+
+fn usage() {
+    println!("usage: cargo run --example tcp_encrypted -- [client|server] [address]");
+    std::process::exit(1);
+}
+
+fn main() {
+    let count = env::args().count();
+    if count != 3 {
+        usage();
+    }
+    let mode = env::args().nth(1).unwrap();
+    let address = env::args().nth(2).unwrap();
+
+    task::block_on(async move {
+        let result = match mode.as_ref() {
+            "server" => tcp_server(address).await,
+            "client" => tcp_client(address).await,
+            _ => panic!(usage()),
+        };
+        if let Err(e) = result {
+            eprintln!("error: {}", e);
+        }
+    });
+}
+
+async fn tcp_server(address: String) -> Result<()> {
+    let listener = TcpListener::bind(&address).await?;
+    println!("Listening on {}", listener.local_addr()?);
+
+    let mut incoming = listener.incoming();
+    while let Some(stream) = incoming.next().await {
+        let stream = stream?;
+        let peer_addr = stream.peer_addr().unwrap();
+        eprintln!("new connection from {}", peer_addr);
+        task::spawn(async move {
+            match handle_incoming(stream).await {
+                Err(ref e) if e.kind() != ErrorKind::UnexpectedEof => {
+                    eprintln!("connection closed from {} with error: {}", peer_addr, e);
+                }
+                Err(_) | Ok(()) => {
+                    eprintln!("connection closed from {}", peer_addr);
+                }
+            }
+        });
+    }
+    Ok(())
+}
+
+async fn tcp_client(address: String) -> Result<()> {
+    let tcp_stream = TcpStream::connect(&address).await?;
+    handle_outgoing(tcp_stream).await?;
+    Ok(())
+}
+
+async fn handle_incoming(stream: TcpStream) -> Result<()> {
+    let (mut reader, mut writer, _cipher) = create_from_stream(stream);
+    while let Some(msg) = reader.try_next().await? {
+        eprintln!("received: {}", format_msg(&msg));
+        if msg.typ == 1 {
+            let resp = Message {
+                channel: msg.channel,
+                typ: 2,
+                message: to_upper(&msg.message),
+            };
+            writer.send(resp).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn handle_outgoing(stream: TcpStream) -> Result<()> {
+    let (mut reader, mut writer, cipher) = create_from_stream(stream);
+
+    // Send unencrypted
+    eprintln!("Send inicial nonce");
+    let nonce_msg = Message::new(0, 0, INITIAL_NONCE.to_vec());
+    writer.send(nonce_msg).await?;
+
+    cipher
+        .write()
+        .expect("could not acquire lock")
+        .initialize(&INITIAL_NONCE);
+
+    // Send encrypted
+    let hello_msg = Message::new(1, 1, "hi".as_bytes().to_vec());
+    writer.send(hello_msg).await?;
+
+    while let Some(msg) = reader.try_next().await? {
+        eprintln!("received: {}", format_msg(&msg));
+    }
+
+    Ok(())
+}
+
+fn create_from_stream(
+    tcp_stream: TcpStream,
+) -> (
+    Reader<CloneableStream>,
+    Writer<CloneableStream>,
+    Arc<RwLock<Cipher>>,
+) {
+    let stream = CloneableStream(Arc::new(tcp_stream));
+    let cipher = Arc::new(RwLock::new(Cipher::new(KEY)));
+    let reader = Reader::encrypted(stream.clone(), cipher.clone(), |message, cypher| {
+        if message.typ == 0 {
+            println!("Received message nonce: {:?}", message);
+            cypher.initialize(&message.message);
+        }
+    });
+    let writer = Writer::encrypted(stream.clone(), cipher.clone());
+    (reader, writer, cipher)
+}
+
+fn format_msg(msg: &Message) -> String {
+    format!(
+        "chan {} typ {} msg {}",
+        msg.channel,
+        msg.typ,
+        String::from_utf8(msg.message.to_vec()).unwrap_or("<invalid utf8>".to_string())
+    )
+}
+
+fn to_upper(bytes: &[u8]) -> Vec<u8> {
+    let string = String::from_utf8(bytes.to_vec()).unwrap();
+    string.to_uppercase().as_bytes().to_vec()
+}
+
+#[derive(Clone)]
+struct CloneableStream(Arc<TcpStream>);
+impl AsyncRead for CloneableStream {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8]) -> Poll<Result<usize>> {
+        Pin::new(&mut &*self.0).poll_read(cx, buf)
+    }
+}
+impl AsyncWrite for CloneableStream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize>> {
+        Pin::new(&mut &*self.0).poll_write(cx, buf)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {
+        Pin::new(&mut &*self.0).poll_flush(cx)
+    }
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {
+        Pin::new(&mut &*self.0).poll_close(cx)
+    }
+}

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1,0 +1,33 @@
+use salsa20::stream_cipher::{NewStreamCipher, SyncStreamCipher};
+use salsa20::XSalsa20;
+use std::sync::{Arc, RwLock};
+
+pub(crate) type SharedCipher = Arc<RwLock<Cipher>>;
+
+type Key = [u8; 32];
+pub struct Cipher {
+    key: Key,
+    cipher: Option<XSalsa20>,
+}
+
+impl Cipher {
+    pub fn new(key: Key) -> Self {
+        Self { key, cipher: None }
+    }
+
+    pub fn empty() -> Self {
+        Self::new([0; 32])
+    }
+
+    pub fn initialize(&mut self, nonce: &[u8]) {
+        self.cipher = XSalsa20::new_var(&self.key, &nonce).ok();
+    }
+
+    pub(crate) fn try_apply(&mut self, buffer: &mut [u8]) {
+        if let Some(ref mut cipher) = &mut self.cipher {
+            cipher
+                .try_apply_keystream(buffer)
+                .expect("inifite stream finished");
+        }
+    }
+}

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -4,19 +4,18 @@ use std::sync::{Arc, RwLock};
 
 pub(crate) type SharedCipher = Arc<RwLock<Cipher>>;
 
-type Key = [u8; 32];
 pub struct Cipher {
-    key: Key,
+    key: Vec<u8>,
     cipher: Option<XSalsa20>,
 }
 
 impl Cipher {
-    pub fn new(key: Key) -> Self {
+    pub fn new(key: Vec<u8>) -> Self {
         Self { key, cipher: None }
     }
 
     pub fn empty() -> Self {
-        Self::new([0; 32])
+        Self::new(vec![0; 32])
     }
 
     pub fn initialize(&mut self, nonce: &[u8]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,12 @@
 //! This module is a port of the JavaScript module [of the same
 //! name](https://github.com/mafintosh/simple-message-channels/).
 
+mod cipher;
 mod message;
 mod reader;
 mod writer;
 
+pub use cipher::Cipher;
 pub use message::Message;
 pub use reader::Reader;
 pub use writer::Writer;

--- a/src/message.rs
+++ b/src/message.rs
@@ -43,12 +43,12 @@ impl Message {
 pub fn decode_message(buf: &[u8]) -> Result<Message, Error> {
     let mut header = 0 as u64;
     let headerlen = varinteger::decode(buf, &mut header);
-    let msg = &buf[headerlen..];
+    let msg = &buf[headerlen..].to_vec();
     let channel = header >> 4;
-    let typ = header & 0b1111;
+    let typ = (header & 0b1111) as u8;
     let message = Message {
-        channel: channel,
-        typ: typ as u8,
+        channel,
+        typ,
         message: msg.to_vec(),
     };
     Ok(message)
@@ -71,6 +71,6 @@ pub fn encode_message(msg: &Message) -> Result<Vec<u8>, Error> {
     varinteger::encode(len_body as u64, &mut buf[..len_prefix]);
     let end = len_prefix + len_header;
     varinteger::encode(header, &mut buf[len_prefix..end]);
-    &mut buf[end..].copy_from_slice(&msg.message);
+    buf[end..].copy_from_slice(&msg.message);
     Ok(buf)
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -112,14 +112,14 @@ where
             .expect("could not aquire lock")
             .try_apply(&mut headerbuf);
         let byte = headerbuf[0];
-        varint = varint + (byte as u64 & 127) * factor;
+        varint += (byte as u64 & 127) * factor;
         if byte < 128 {
             break;
         }
         if varint > MAX_MESSAGE_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "Message too long"));
         }
-        factor = factor * 128;
+        factor *= 128;
     }
 
     // Read main message.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,8 @@
+use futures::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 use std::io::Error;
-use futures::io::{AsyncWrite,AsyncWriteExt,BufWriter};
+use std::sync::{Arc, RwLock};
+
+use crate::cipher::{Cipher, SharedCipher};
 use crate::Message;
 
 /// A writer for SMC messages.
@@ -7,6 +10,7 @@ use crate::Message;
 /// Consumes an [`futures::io::AsyncWrite`] to which messages will be written.
 pub struct Writer<W> {
     writer: BufWriter<W>,
+    cipher: SharedCipher,
 }
 
 impl<W> Writer<W>
@@ -15,8 +19,13 @@ where
 {
     /// Create a new message writer.
     pub fn new(writer: W) -> Self {
+        Self::encrypted(writer, Arc::new(RwLock::new(Cipher::empty())))
+    }
+
+    pub fn encrypted(writer: W, cipher: SharedCipher) -> Self {
         Self {
             writer: BufWriter::new(writer),
+            cipher,
         }
     }
 
@@ -24,7 +33,11 @@ where
     ///
     /// This encodes the message, writes it and flushes the writer.
     pub async fn send(&mut self, message: Message) -> Result<(), Error> {
-        let buf = message.encode()?;
+        let mut buf = message.encode()?;
+        self.cipher
+            .write()
+            .expect("could not aquire lock")
+            .try_apply(&mut buf);
         self.writer.write_all(&buf).await?;
         self.writer.flush().await?;
         Ok(())
@@ -35,7 +48,11 @@ where
     /// This works like [`Writer::send`] but flushes after all messages are written.
     pub async fn send_batch(&mut self, messages: Vec<Message>) -> Result<(), Error> {
         for message in &messages {
-            let buf = message.encode()?;
+            let mut buf = message.encode()?;
+            self.cipher
+                .write()
+                .expect("could not aquire lock")
+                .try_apply(&mut buf);
             self.writer.write_all(&buf).await?;
         }
         self.writer.flush().await?;


### PR DESCRIPTION
This commit includes encryption to messages. Initial messages are
allowed to start un-encrypted, when written. When a new message is read,
the information received can be used to initialize the stream.

If there is no encryption happening, it will not encrypt the buffer
produce unencrypted.

This used a share-able Cipher struct, allowing for the read and writer
control when it should be encrypted. This means that the initiator can
send an unencrypted message, and wait for the encrypted message using
the information sent.

An example is provided, showing it can be run both by an uncripted
client and a encrypted client.

Example:

```sh
cargo run --example tcp_encrypted -- server localhost:8080
``

```sh
cargo run --example tcp_encrypted -- server localhost:8080
cargo run --example tcp -- client localhost:8080
```

Only XSalsa20 is supported at this moment. A trait could be provided to
extend the design to other ciphers, but this is not proposed here.

Related to: https://github.com/datrs/simple-message-channels/issues/3