### PR TITLE
Remove internal buffering

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,12 +1,12 @@
-use std::io::Error;
-use futures::io::{AsyncWrite,AsyncWriteExt,BufWriter};
 use crate::Message;
+use futures::io::{AsyncWrite, AsyncWriteExt};
+use std::io::Error;
 
 /// A writer for SMC messages.
 ///
 /// Consumes an [`futures::io::AsyncWrite`] to which messages will be written.
 pub struct Writer<W> {
-    writer: BufWriter<W>,
+    writer: W,
 }
 
 impl<W> Writer<W>
@@ -15,9 +15,7 @@ where
 {
     /// Create a new message writer.
     pub fn new(writer: W) -> Self {
-        Self {
-            writer: BufWriter::new(writer),
-        }
+        Self { writer }
     }
 
     /// Send a message.


### PR DESCRIPTION
Using the split strategy to upgrade the underlying `Reader<R>` from an
plain channel to an encrypted channel caused some data-loss.

The plain channel inside the `Reader` would also buffer encrypted
bytes that would go missing from the encrypted `Reader`.

From the docs, we can see this is an issue:
```
When the BufReader<R> is dropped, the contents of its buffer will be
discarded. Creating multiple instances of a BufReader<R> on the same
stream can cause data loss.
```
https://doc.rust-lang.org/std/io/struct.BufReader.html

This commit removes the `BufReader` and `BufWriter` from the crate. This
moves the responsability of the caller to wrap the encrypted channel
into a BufReader/BufWriter and leave the plain channel unbuffered.

[Example](https://github.com/bltavares/colmeia/blob/54f3c10f1a5e077d61999703fc2628496c5c9e68/colmeia-dat-proto/src/lib.rs#L151)